### PR TITLE
Add accounts api unit tests

### DIFF
--- a/accounts/api/tests.py
+++ b/accounts/api/tests.py
@@ -1,0 +1,132 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+LOGIN_URL = '/api/accounts/login/'
+LOGOUT_URL = '/api/accounts/logout/'
+SIGNUP_URL = '/api/accounts/signup/'
+LOGIN_STATUS_URL = '/api/accounts/login_status/'
+
+
+class AccountApiTests(TestCase):
+
+    def setUp(self):
+        # 这个函数会在每个 test function 执行的时候被执行
+        self.client = APIClient()
+        self.user = self.create_user(
+            username='test',
+            email='test@twitter.com',
+            password='correct password',
+        )
+
+    def create_user(self, username, email, password):
+        # 不能写成 User.objects.create()
+        # 因为 password 需要被加密, username 和 email 需要进行一些 normalize 处理
+        return User.objects.create_user(username, email, password)
+
+    def test_login(self):
+        # 每个测试函数必须以 test_ 开头，才会被自动调用进行测试
+
+        # 验证必须用 post 而不是 get
+        response = self.client.get(LOGIN_URL, {
+            'username': self.user.username,
+            'password': 'correct password',
+        })
+        # 登陆失败，http status code 返回 405 = METHOD_NOT_ALLOWED
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        # 用了 post 但是密码错了
+        response = self.client.post(LOGIN_URL, {
+            'username': self.user.username,
+            'password': 'wrong password',
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # 验证还没有登录
+        response = self.client.get(LOGIN_STATUS_URL)
+        self.assertEqual(response.data['has_logged_in'], False)
+
+        # 用正确的密码登录
+        response = self.client.post(LOGIN_URL, {
+            'username': self.user.username,
+            'password': 'correct password',
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(response.data['user'], None)
+        self.assertEqual(response.data['user']['email'], 'test@twitter.com')
+        # 验证已经登录了
+        response = self.client.get(LOGIN_STATUS_URL)
+        self.assertEqual(response.data['has_logged_in'], True)
+
+        # 用了 post 但是username错了
+        response = self.client.post(LOGIN_URL, {
+            'username': 'not_exists',
+            'password': 'correct password',
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_logout(self):
+        # 先登录
+        self.client.post(LOGIN_URL, {
+            'username': self.user.username,
+            'password': 'correct password',
+        })
+        # 验证用户已经登录
+        response = self.client.get(LOGIN_STATUS_URL)
+        self.assertEqual(response.data['has_logged_in'], True)
+
+        # 验证必须用 post 而不是 get
+        response = self.client.get(LOGOUT_URL)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        # 改用 post 成功 logout
+        response = self.client.post(LOGOUT_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # 验证用户已经登出
+        response = self.client.get(LOGIN_STATUS_URL)
+        self.assertEqual(response.data['has_logged_in'], False)
+
+    def test_signup(self):
+        data = {
+            'username': 'someone',
+            'email': 'someone@twitter.com',
+            'password': 'any password',
+        }
+
+        # 验证 get 请求失败
+        response = self.client.get(SIGNUP_URL, data)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        # 测试错误的邮箱
+        response = self.client.post(SIGNUP_URL, {
+            'username': 'someone',
+            'email': 'not a correct email',
+            'password': 'any password',
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # 测试过短密码
+        response = self.client.post(SIGNUP_URL, {
+            'username': 'someone',
+            'email': 'someone@twitter.com',
+            'password': '123',
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # 测试过长用户名
+        response = self.client.post(SIGNUP_URL, {
+            'username': 'username is tooooooooooooooooo loooooooong',
+            'email': 'someone@twitter.com',
+            'password': 'any password',
+        })
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # 验证成功注册
+        response = self.client.post(SIGNUP_URL, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['user']['username'], 'someone')
+        # 验证用户已经登入
+        response = self.client.get(LOGIN_STATUS_URL)
+        self.assertEqual(response.data['has_logged_in'], True)


### PR DESCRIPTION
给 Accounts API 增加单元测试、
验证方法: 在 vagrant 中执行 `python manage.py test` 可以成功通过测试