### PR TITLE
Inject likes info to other apis reading likes

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -5,9 +5,11 @@ from comments.models import Comment
 from testing.testcases import TestCase
 from rest_framework.test import APIClient
 
-
 COMMENT_URL = '/api/comments/'
 COMMENT_DETAIL_URL = '/api/comments/{}/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class CommentApiTests(TestCase):
@@ -138,3 +140,24 @@ class CommentApiTests(TestCase):
             'user_id': self.lisa.id,
         })
         self.assertEqual(len(response.data['comments']), 2)
+
+    def test_comments_count(self):
+        # test tweet detail api
+        tweet = self.create_tweet(self.lisa)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.emma_client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        # test tweet list api
+        self.create_comment(self.lisa, tweet)
+        response = self.emma_client.get(TWEET_LIST_API, {'user_id': self.lisa.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['tweets'][0]['comments_count'], 1)
+
+        # test newsfeeds list api
+        self.create_comment(self.emma, tweet)
+        self.create_newsfeed(self.emma, tweet)
+        response = self.emma_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -46,7 +46,11 @@ class CommentViewSet(viewsets.GenericViewSet):
         comments = self.filter_queryset(queryset=queryset)\
             .prefetch_related('user')\
             .order_by('created_at')
-        serializer = CommentSerializer(instance=comments, many=True)
+        serializer = CommentSerializer(
+            instance=comments,
+            context={'request': request},
+            many=True,
+        )
 
         return Response({
             'comments': serializer.data,
@@ -73,7 +77,10 @@ class CommentViewSet(viewsets.GenericViewSet):
 
         comment = serializer.save()
         return Response(
-            data=CommentSerializer(comment).data,
+            data=CommentSerializer(
+                instance=comment,
+                context={'request': request},
+            ).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -105,7 +112,10 @@ class CommentViewSet(viewsets.GenericViewSet):
         # save 是根据 instance 参数有没有传来决定是触发 create 还是 update
         comment = serializer.save()
         return Response(
-            data=CommentSerializer(comment).data,
+            data=CommentSerializer(
+                instance=comment,
+                context={'request': request},
+            ).data,
             status=status.HTTP_200_OK,
         )
 

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -5,6 +5,10 @@ from testing.testcases import TestCase
 
 LIKE_BASE_URL = '/api/likes/'
 LIKE_CANCEL_URL = '/api/likes/cancel/'
+COMMENT_LIST_API = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class LikeApiTests(TestCase):
@@ -152,3 +156,66 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.data['deleted'], True)
         self.assertEqual(tweet.like_set.count(), 0)
         self.assertEqual(comment.like_set.count(), 0)
+
+    def test_likes_in_comments_api(self):
+        tweet = self.create_tweet(self.lisa)
+        comment = self.create_comment(self.lisa, tweet)
+
+        # test anonymous
+        response = self.anonymous_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+
+        # test comments list api
+        response = self.emma_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+        self.create_like(self.emma, comment)
+        response = self.emma_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 1)
+
+        # test tweet detail api
+        self.create_like(self.lisa, comment)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.emma_client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 2)
+
+    def test_likes_in_tweets_api(self):
+        tweet = self.create_tweet(self.lisa)
+
+        # test tweet detail api
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.emma_client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['has_liked'], False)
+        self.assertEqual(response.data['likes_count'], 0)
+        self.create_like(self.emma, tweet)
+        response = self.emma_client.get(url)
+        self.assertEqual(response.data['has_liked'], True)
+        self.assertEqual(response.data['likes_count'], 1)
+
+        # test tweets list api
+        response = self.emma_client.get(TWEET_LIST_API, {'user_id': self.lisa.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
+        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+
+        # test newsfeeds list api
+        self.create_like(self.lisa, tweet)
+        self.create_newsfeed(self.emma, tweet)
+        response = self.emma_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+
+        # test likes details
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.emma_client.get(url)
+        self.assertEqual(len(response.data['likes']), 2)
+        self.assertEqual(response.data['likes'][0]['user']['id'], self.lisa.id)
+        self.assertEqual(response.data['likes'][1]['user']['id'], self.emma.id)

--- a/likes/services.py
+++ b/likes/services.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+
+from likes.models import Like
+
+
+class LikeService:
+
+    @classmethod
+    def has_liked(cls, user: User, target):
+        """
+        查看 user 是否点赞过这个 object (tweet / comment)
+        """
+        if user.is_anonymous:
+            return False
+
+        return Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(target.__class__),
+            object_id=target.id,
+            user=user,
+        ).exists()

--- a/newsfeeds/api/serializers.py
+++ b/newsfeeds/api/serializers.py
@@ -5,7 +5,7 @@ from tweets.api.serializers import TweetSerializer
 
 
 class NewsFeedSerializer(serializers.ModelSerializer):
-    tweet = TweetSerializer()
+    tweet = TweetSerializer()  # 因 TweetSerializer 中需传入 context，故用到 NewsFeedSerializer 的地方也需要传入context
 
     class Meta:
         model = NewsFeed

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -15,7 +15,11 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user_id=self.request.user.id)
 
     def list(self, request: Request):
-        serializer = NewsFeedSerializer(instance=self.get_queryset(), many=True)
+        serializer = NewsFeedSerializer(
+            instance=self.get_queryset(),
+            context={'request': request},
+            many=True,
+        )
         return Response({
             'newsfeeds': serializer.data
         }, status=status.HTTP_200_OK)

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -5,6 +5,7 @@ from rest_framework.test import APIClient
 
 from comments.models import Comment
 from likes.models import Like
+from newsfeeds.models import NewsFeed
 from tweets.models import Tweet
 
 
@@ -35,6 +36,9 @@ class TestCase(DjangoTestCase):
         if content is None:
             content = 'default tweet content'
         return Tweet.objects.create(user=user, content=content)
+
+    def create_newsfeed(self, user, tweet):
+        return NewsFeed.objects.create(user=user, tweet=tweet)
 
     def create_comment(self, user, tweet, content=None):
         if content is None:

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,15 +1,46 @@
 from rest_framework import serializers
 from accounts.api.serializers import UserSerializerForTweet, UserSerializer
 from comments.api.serializers import CommentSerializer
+from likes.api.serializers import LikeSerializer
+from likes.services import LikeService
 from tweets.models import Tweet
 
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet()  # 会返回具体user被serialize过的信息，若不指定只会返回user_id
+    comments_count = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'content',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_comments_count(self, obj):
+        """
+        查看有多少人评论了当前 object (tweet)
+        """
+        return obj.comment_set.count()  # django的ForeignKey的反查机制
+
+    def get_likes_count(self, obj):
+        """
+        查看有多少人点赞了当前 object (tweet)
+        """
+        return obj.like_set.count()  # like_set为自定义的 Tweet 的 property
+
+    def get_has_liked(self, obj):
+        """
+        查看当前登录的用户是否赞过这个 object (tweet)
+        """
+        return LikeService.has_liked(user=self.context['request'].user, target=obj)
 
 
 class TweetSerializerForCreate(serializers.ModelSerializer):
@@ -27,9 +58,10 @@ class TweetSerializerForCreate(serializers.ModelSerializer):
         return tweet
 
 
-class TweetSerializerWithComments(serializers.ModelSerializer):
+class TweetSerializerForDetail(TweetSerializer):
     user = UserSerializer()
     comments = CommentSerializer(source='comment_set', many=True)
+    likes = LikeSerializer(source='like_set', many=True)
 
     # # 使用 serializers.SerializerMethodField 实现 comments
     # comments = serializers.SerializerMethodField()
@@ -39,4 +71,15 @@ class TweetSerializerWithComments(serializers.ModelSerializer):
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'comments', 'created_at', 'content',)
+        fields = (
+            'id',
+            'user',
+            'comments',
+            'created_at',
+            'content',
+            'likes',
+            'comments',
+            'likes_count',
+            'comments_count',
+            'has_liked',
+        )


### PR DESCRIPTION
1. Inject likes info to other apis that will read like (tweets & comments api); the info including `has_liked` and `likes_count`
2. Add `comments_count` field for comment demostration serializer
3. Add `LikeService.has_liked(user, target)` to return whether a user has liked a target
4. Add unit test to test apis