### PR TITLE
Support newsfeeds pagination (endless pagination)

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -160,4 +160,4 @@ class CommentApiTests(TestCase):
         self.create_newsfeed(self.emma, tweet)
         response = self.emma_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)
+        self.assertEqual(response.data['results'][0]['tweet']['comments_count'], 2)

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -210,8 +210,8 @@ class LikeApiTests(TestCase):
         self.create_newsfeed(self.emma, tweet)
         response = self.emma_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+        self.assertEqual(response.data['results'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 2)
 
         # test likes details
         url = TWEET_DETAIL_API.format(tweet.id)

--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from testing.testcases import TestCase
+from utils.paginations import EndlessPagination
 
 NEWSFEEDS_URL = '/api/newsfeeds/'
 POST_TWEETS_URL = '/api/tweets/'
@@ -29,11 +30,11 @@ class NewsFeedApiTests(TestCase):
         # 验证一开始啥都没有
         response = self.lisa_client.get(NEWSFEEDS_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['newsfeeds']), 0)
+        self.assertEqual(len(response.data['results']), 0)
         # 验证自己发的信息是可以看到的
         self.lisa_client.post(POST_TWEETS_URL, {'content': 'Hello World'})
         response = self.lisa_client.get(NEWSFEEDS_URL)
-        self.assertEqual(len(response.data['newsfeeds']), 1)
+        self.assertEqual(len(response.data['results']), 1)
         # 验证关注之后可以看到别人发的
         self.lisa_client.post(FOLLOW_URL.format(self.emma.id))
         response = self.emma_client.post(POST_TWEETS_URL, {
@@ -41,5 +42,61 @@ class NewsFeedApiTests(TestCase):
         })
         posted_tweet_id = response.data['id']
         response = self.lisa_client.get(NEWSFEEDS_URL)
-        self.assertEqual(len(response.data['newsfeeds']), 2)  # 看到自己发了一条，看到emma发了一条
-        self.assertEqual(response.data['newsfeeds'][0]['tweet']['id'], posted_tweet_id)
+        self.assertEqual(len(response.data['results']), 2)  # 看到自己发了一条，看到emma发了一条
+        self.assertEqual(response.data['results'][0]['tweet']['id'], posted_tweet_id)
+
+    def test_pagination(self):
+        page_size = EndlessPagination.page_size
+        followed_user = self.create_user('followed')
+        newsfeeds = []
+        for i in range(page_size * 2):
+            tweet = self.create_tweet(followed_user)
+            newsfeed = self.create_newsfeed(user=self.lisa, tweet=tweet)
+            newsfeeds.append(newsfeed)
+
+        newsfeeds = newsfeeds[::-1]
+
+        # pull the first page
+        response = self.lisa_client.get(NEWSFEEDS_URL)
+        self.assertEqual(response.data['has_next_page'], True)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['results'][0]['id'], newsfeeds[0].id)
+        self.assertEqual(response.data['results'][1]['id'], newsfeeds[1].id)
+        self.assertEqual(
+            response.data['results'][page_size - 1]['id'],
+            newsfeeds[page_size - 1].id,
+        )
+
+        # pull the second page
+        response = self.lisa_client.get(
+            NEWSFEEDS_URL,
+            {'created_at__lt': newsfeeds[page_size - 1].created_at},
+        )
+        self.assertEqual(response.data['has_next_page'], False)
+        results = response.data['results']
+        self.assertEqual(len(results), page_size)
+        self.assertEqual(results[0]['id'], newsfeeds[page_size].id)
+        self.assertEqual(results[1]['id'], newsfeeds[page_size + 1].id)
+        self.assertEqual(
+            results[page_size - 1]['id'],
+            newsfeeds[2 * page_size - 1].id,
+        )
+
+        # pull latest newsfeeds
+        response = self.lisa_client.get(
+            NEWSFEEDS_URL,
+            {'created_at__gt': newsfeeds[0].created_at},
+        )
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), 0)
+
+        tweet = self.create_tweet(followed_user)
+        new_newsfeed = self.create_newsfeed(user=self.lisa, tweet=tweet)
+
+        response = self.lisa_client.get(
+            NEWSFEEDS_URL,
+            {'created_at__gt': newsfeeds[0].created_at},
+        )
+        self.assertEqual(response.data['has_next_page'], False)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['id'], new_newsfeed.id)

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -1,7 +1,6 @@
-from rest_framework import viewsets, status
+from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
-from rest_framework.response import Response
 from newsfeeds.api.serializers import NewsFeedSerializer
 from newsfeeds.models import NewsFeed
 from utils.paginations import EndlessPagination

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -4,10 +4,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from newsfeeds.api.serializers import NewsFeedSerializer
 from newsfeeds.models import NewsFeed
+from utils.paginations import EndlessPagination
 
 
 class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
+    pagination_class = EndlessPagination
 
     def get_queryset(self):
         # 重载以自定义 queryset，因为 newsfeed 的查看是有权限的
@@ -15,11 +17,13 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user_id=self.request.user.id)
 
     def list(self, request: Request):
+        """
+        GET /api/newsfeeds/
+        """
+        page = self.paginate_queryset(self.get_queryset())
         serializer = NewsFeedSerializer(
-            instance=self.get_queryset(),
+            instance=page,
             context={'request': request},
             many=True,
         )
-        return Response({
-            'newsfeeds': serializer.data
-        }, status=status.HTTP_200_OK)
+        return self.get_paginated_response(data=serializer.data)


### PR DESCRIPTION
1. Modify `NewsFeedViewSet` to make queryset and response paginated via endless pagination
2. Add unit test to test newsfeeds pagination