### PR TITLE
Add user and user profile cache

### DIFF
--- a/accounts/api/tests.py
+++ b/accounts/api/tests.py
@@ -17,6 +17,7 @@ class AccountApiTests(TestCase):
 
     def setUp(self):
         # 这个函数会在每个 test function 执行的时候被执行
+        self.clear_cache()
         self.client = APIClient()
         self.user = self.create_user(
             username='test',

--- a/accounts/listeners.py
+++ b/accounts/listeners.py
@@ -1,0 +1,9 @@
+def user_changed(sender, instance, **kwargs):
+    # import 写在函数里面避免循环依赖
+    from accounts.services import UserService
+    UserService.invalidate_user(instance.id)
+
+def profile_changed(sender, instance, **kwargs):
+    # import 写在函数里面避免循环依赖
+    from accounts.services import UserService
+    UserService.invalidate_profile(instance.user_id)

--- a/accounts/services.py
+++ b/accounts/services.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import caches
+
+from accounts.models import UserProfile
+from twitter.cache import USER_PATTERN, USER_PROFILE_PATTERN
+
+cache = caches['testing'] if settings.TESTING else caches['default']
+
+
+class UserService:
+
+    @classmethod
+    def get_user_through_cache(cls, user_id):
+        key = USER_PATTERN.format(user_id=user_id)
+
+        # read from cache first
+        user = cache.get(key)
+        # cache hit, return
+        if user is not None:
+            return user
+
+        # cache miss, read from db
+        try:
+            user = User.objects.get(id=user_id)
+            cache.set(key, user)
+        except User.DoesNotExist: # db 中 user table 也找不到
+            user= None
+        return user
+
+    @classmethod
+    def invalidate_user(cls, user_id):
+        key = USER_PATTERN.format(user_id=user_id)
+        cache.delete(key)
+
+    @classmethod
+    def get_profile_through_cache(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
+
+        # read from cache first
+        profile = cache.get(key)
+        # cache hit, return
+        if profile is not None:
+            return profile
+
+        # cache miss, read from db
+        # 因为历史原因，user profile 是后面加进来的。可能有一些历史数据没有 profile
+        profile, _ = UserProfile.objects.get_or_create(user_id=user_id)
+        cache.set(key, profile)
+        return profile
+
+    @classmethod
+    def invalidate_profile(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
+        cache.delete(key)

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -5,6 +5,9 @@ from testing.testcases import TestCase
 # Create your tests here.
 class UserProfileTests(TestCase):
 
+    def setUp(self):
+        self.clear_cache()
+
     def test_profile_property(self):
         lisa = self.create_user('lisa')
         self.assertEqual(UserProfile.objects.count(), 0)

--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -8,7 +8,7 @@ from tweets.models import Tweet
 
 
 class CommentSerializer(serializers.ModelSerializer):
-    user = UserSerializerForComment()  # 若不加这行，下面 fields 中的 user 会以 id 的形式显示
+    user = UserSerializerForComment(source='cached_user')  # 若不加这行，下面 fields 中的 user 会以 id 的形式显示
     likes_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()
 

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -15,6 +15,7 @@ NEWSFEED_LIST_API = '/api/newsfeeds/'
 class CommentApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.lisa = self.create_user('lisa')
         self.lisa_client = APIClient()
         self.lisa_client.force_authenticate(self.lisa)
@@ -42,7 +43,7 @@ class CommentApiTests(TestCase):
         response = self.lisa_client.post(COMMENT_URL, {'content': '1'})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # 验证content 太长不行
+        # 验证 content 太长不行
         response = self.lisa_client.post(COMMENT_URL, {
             'tweet_id': self.tweet.id,
             'content': '1' * 141,  # max_length=140
@@ -50,7 +51,7 @@ class CommentApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('content' in response.data['errors'], True)
 
-        # 验证tweet_id 和 content 都带才行
+        # 验证 tweet_id 和 content 都带才行
         response = self.lisa_client.post(COMMENT_URL, {
             'tweet_id': self.tweet.id,
             'content': '1',

--- a/comments/models.py
+++ b/comments/models.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
+from accounts.services import UserService
 from likes.models import Like
 from tweets.models import Tweet
 
@@ -21,13 +22,6 @@ class Comment(models.Model):
         # 有在某个 tweet 下排序所有 comments 的需求
         index_together = (('tweet', 'created_at'),)
 
-    @property
-    def like_set(self):
-        return Like.objects.filter(
-            content_type=ContentType.objects.get_for_model(Comment),
-            object_id=self.id,
-        ).order_by('-created_at')
-
     def __str__(self):
         return '{} - {} says {} at tweet {}'.format(
             self.created_at,
@@ -35,3 +29,14 @@ class Comment(models.Model):
             self.content,
             self.tweet_id
         )
+
+    @property
+    def like_set(self):
+        return Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(Comment),
+            object_id=self.id,
+        ).order_by('-created_at')
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -5,6 +5,7 @@ from testing.testcases import TestCase
 class CommentModelTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.lisa = self.create_user('lisa')
         self.tweet = self.create_tweet(user=self.lisa)
         self.comment = self.create_comment(user=self.lisa, tweet=self.tweet)

--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -32,7 +32,7 @@ class FollowingUserIdSetMixin:
 class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     # 可以通过 source=xxx 指定去访问每个 model instance 的 xxx field或property
     # 即 model_instance.xxx 来获得数据
-    user = UserSerializerForFriendship(source='from_user')
+    user = UserSerializerForFriendship(source='cached_from_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
 
@@ -43,7 +43,7 @@ class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     def get_has_followed(self, obj: Friendship):
         # if self.context['request'].user.is_anonymous:
         #     return False
-        # # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
+        # # 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
         # # 我们将在后序优化中会用 cache 解决这个问题
         # return FriendshipService.has_followed(
         #     from_user=self.context['request'].user,
@@ -55,7 +55,7 @@ class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
 
 
 class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    user = UserSerializerForFriendship(source='to_user')
+    user = UserSerializerForFriendship(source='cached_to_user')
     created_at = serializers.DateTimeField()
     has_followed = serializers.SerializerMethodField()
 
@@ -66,7 +66,7 @@ class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     def get_has_followed(self, obj: Friendship):
         # if self.context['request'].user.is_anonymous:
         #     return False
-        # # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
+        # # 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
         # # 我们将在后序优化中会用 cache 解决这个问题
         # return FriendshipService.has_followed(
         #     from_user=self.context['request'].user,

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -85,7 +85,8 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         serializer.save()
 
         # friendship 有更新，需要将 cache 中的 key 失效
-        FriendshipService.invalidate_following_cache(from_user_id=request.user.id)
+        # 已经加了 listener，此处无需手动 invalidate 了
+        # FriendshipService.invalidate_following_cache(from_user_id=request.user.id)
 
         return Response({
             'success': True,
@@ -115,7 +116,8 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         ).delete()
 
         # friendship 有更新，需要将 cache 中的 key 失效
-        FriendshipService.invalidate_following_cache(from_user_id=request.user.id)
+        # 已经加了 listener，此处无需手动 invalidate 了
+        # FriendshipService.invalidate_following_cache(from_user_id=request.user.id)
 
         return Response({
             'success': True,

--- a/friendships/listeners.py
+++ b/friendships/listeners.py
@@ -1,0 +1,4 @@
+def friendship_changed(sender, instance, **kwargs):
+    # import 写在函数里面避免循环依赖
+    from friendships.services import FriendshipService
+    FriendshipService.invalidate_following_cache(instance.from_user_id)

--- a/friendships/models.py
+++ b/friendships/models.py
@@ -3,6 +3,12 @@ from django.db import models
 
 
 # Create your models here.
+from django.db.models.signals import pre_delete, post_save
+
+from accounts.services import UserService
+from friendships.listeners import friendship_changed
+
+
 class Friendship(models.Model):
     from_user = models.ForeignKey(
         User,
@@ -28,4 +34,17 @@ class Friendship(models.Model):
         unique_together = (('from_user_id', 'to_user_id'),)
 
     def __str__(self):
-        return '{} followed {}'.format(self.from_user_id, self.to_user_id )
+        return '{} followed {}'.format(self.from_user_id, self.to_user_id)
+
+    @property
+    def cached_from_user(self):
+        return UserService.get_user_through_cache(self.from_user_id)
+
+    @property
+    def cached_to_user(self):
+        return UserService.get_user_through_cache(self.to_user_id)
+
+
+# hook up with listeners to invalidate cache
+pre_delete.connect(friendship_changed, sender=Friendship)
+post_save.connect(friendship_changed, sender=Friendship)

--- a/friendships/tests.py
+++ b/friendships/tests.py
@@ -16,12 +16,15 @@ class FriendshipServiceTests(TestCase):
         user2 = self.create_user('user2')
         for to_user in [user1, user2, self.emma]:
             Friendship.objects.create(from_user=self.lisa, to_user=to_user)
-        FriendshipService.invalidate_following_cache(self.lisa.id)
+        # 此处不是通过 api 调用来 follow，在没有加 listener 的情况下，需要手动 invalidate
+        # 如果加了 listener，这一行就不需要了
+        # FriendshipService.invalidate_following_cache(self.lisa.id)
 
         user_id_set = FriendshipService.get_following_user_id_set(self.lisa.id)
         self.assertSetEqual(user_id_set, {user1.id, user2.id, self.emma.id})
 
         Friendship.objects.filter(from_user=self.lisa, to_user=self.emma).delete()
-        FriendshipService.invalidate_following_cache(self.lisa.id)
+        # 如果加了 listener，这一行就不需要了
+        # FriendshipService.invalidate_following_cache(self.lisa.id)
         user_id_set = FriendshipService.get_following_user_id_set(self.lisa.id)
         self.assertSetEqual(user_id_set, {user1.id, user2.id})

--- a/inbox/api/tests.py
+++ b/inbox/api/tests.py
@@ -14,6 +14,7 @@ NOTIFICATION_UPDATE_URL = '/api/notifications/{}/'
 class NotificationTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.lisa, self.lisa_client = self.create_user_and_client('lisa')
         self.emma, self.emma_client = self.create_user_and_client('emma')
         self.emma_tweet = self.create_tweet(self.emma)

--- a/inbox/tests.py
+++ b/inbox/tests.py
@@ -8,6 +8,7 @@ from testing.testcases import TestCase
 class NotificationServiceTest(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.lisa = self.create_user('lisa')
         self.emma = self.create_user('emma')
         self.lisa_tweet = self.create_tweet(self.lisa)

--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -2,18 +2,28 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from accounts.api.serializers import UserSerializer
+from accounts.api.serializers import UserSerializerForLike
 from comments.models import Comment
 from likes.models import Like
 from tweets.models import Tweet
 
 
 class LikeSerializer(serializers.ModelSerializer):
-    user = UserSerializer()
+    # source 表示去 model 里取一个函数或属性来作为这个渲染时用的内容
+    user = UserSerializerForLike(source='cached_user')
+    # 法二：
+    # user = serializers.SerializerMethodField()
 
     class Meta:
         model = Like
         fields = ('user', 'created_at',)
+
+    # 法二：
+    # def get_user(self, obj):
+    #     from accounts.services import UserService
+    #     # 不要用 user.id，会实际访问数据库
+    #     user = UserService.get_profile_through_cache(obj.user_id)
+    #     return UserSerializerForLike(instance=user).data
 
 
 class BaseLikeSerializerForCreateAndCancel(serializers.ModelSerializer):

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -14,6 +14,7 @@ NEWSFEED_LIST_API = '/api/newsfeeds/'
 class LikeApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.lisa, self.lisa_client = self.create_user_and_client('lisa')
         self.emma, self.emma_client = self.create_user_and_client('emma')
 

--- a/likes/models.py
+++ b/likes/models.py
@@ -5,6 +5,9 @@ from django.db import models
 
 
 # Create your models here.
+from accounts.services import UserService
+
+
 class Like(models.Model):
     """
     可以点赞一个 tweet，也可以点赞一个 comment
@@ -42,3 +45,7 @@ class Like(models.Model):
             self.content_type,
             self.object_id,
         )
+
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)

--- a/newsfeeds/api/serializers.py
+++ b/newsfeeds/api/serializers.py
@@ -5,8 +5,11 @@ from tweets.api.serializers import TweetSerializer
 
 
 class NewsFeedSerializer(serializers.ModelSerializer):
-    tweet = TweetSerializer()  # 因 TweetSerializer 中需传入 context，故用到 NewsFeedSerializer 的地方也需要传入context
+    # 因 TweetSerializer 中需传入 context，
+    # 故用到 NewsFeedSerializer 的地方也需要传入context
+    tweet = TweetSerializer()
 
     class Meta:
         model = NewsFeed
-        fields = ('id', 'created_at', 'tweet')  # 不需要user，TweetSerializer中包含user
+        # 不需要user，TweetSerializer中包含user
+        fields = ('id', 'created_at', 'tweet')

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -12,7 +12,7 @@ from tweets.services import TweetService
 
 class TweetSerializer(serializers.ModelSerializer):
     # 会返回具体user被serialize过的信息，若不指定只会返回user_id
-    user = UserSerializerForTweet()
+    user = UserSerializerForTweet(source='cached_user')
     comments_count = serializers.SerializerMethodField()
     likes_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -16,6 +16,7 @@ TWEET_RETRIEVE_API = '/api/tweets/{}/'
 class TweetApiTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.user1 = self.create_user(username='user1', email='user1@twitter.com')
         self.tweets1 = [
             self.create_tweet(user=self.user1)

--- a/tweets/models.py
+++ b/tweets/models.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
+from accounts.services import UserService
 from likes.models import Like
 from tweets.constants import TweetPhotoStatus, TWEET_PHOTO_STATUS_CHOICES
 from utils.time_helpers import utc_now
@@ -21,6 +22,10 @@ class Tweet(models.Model):
     class Meta:
         index_together = (('user', 'created_at'),)
         ordering = ('user', '-created_at')
+
+    def __str__(self):
+        # 这里是你执行 print(tweet instance) 的时候会显示的内容
+        return f'{self.created_at} {self.user}: {self.content}'
 
     @property
     def hours_to_now(self):
@@ -44,9 +49,9 @@ class Tweet(models.Model):
             object_id=self.id,
         ).order_by('-created_at')
 
-    def __str__(self):
-        # 这里是你执行 print(tweet instance) 的时候会显示的内容
-        return f'{self.created_at} {self.user}: {self.content}'
+    @property
+    def cached_user(self):
+        return UserService.get_user_through_cache(self.user_id)
 
 
 class TweetPhoto(models.Model):

--- a/tweets/tests.py
+++ b/tweets/tests.py
@@ -10,6 +10,7 @@ from utils.time_helpers import utc_now
 class TweetTests(TestCase):
 
     def setUp(self):
+        self.clear_cache()
         self.lisa = self.create_user(username='lisa')
         self.tweet = self.create_tweet(user=self.lisa)
 

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,2 +1,5 @@
 # memcached
 FOLLOWINGS_PATTERN = 'followings:{user_id}'
+USER_PATTERN = 'user:{user_id}'
+# 通常会把 user_id 作为外键放在很多表单中，而不会把 user profile id 作为外键
+USER_PROFILE_PATTERN = 'userprofile:{user_id}'


### PR DESCRIPTION
1. Add cache for user and user profile: `get_user_through_cache` and `get_profile_through_cache`
2. Add listener for user and friendship
3. Modify user, tweet, like, comment serializers to utilize the cache
4. Add unit test for newsfeeds to test the cache