### PR TITLE
Limit cache size in Redis

### DIFF
--- a/newsfeeds/api/tests.py
+++ b/newsfeeds/api/tests.py
@@ -1,6 +1,9 @@
+from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from newsfeeds.models import NewsFeed
+from newsfeeds.services import NewsFeedService
 from testing.testcases import TestCase
 from utils.paginations import EndlessPagination
 
@@ -159,3 +162,54 @@ class NewsFeedApiTests(TestCase):
         results = response.data['results']
         # validate that the tweet content is updated in newsfeeds
         self.assertEqual(results[0]['tweet']['content'], 'content2')
+
+    # 没有以 test 开头，所以不会被当成单元测试
+    def _paginate_to_get_newsfeeds(self, client):
+        # paginate until the end
+        response = client.get(NEWSFEEDS_URL)
+        results = response.data['results']
+        while response.data['has_next_page']:
+            created_at__lt = response.data['results'][-1]['created_at']
+            response = client.get(NEWSFEEDS_URL, {'created_at__lt': created_at__lt})
+            results.extend(response.data['results'])
+        return results
+
+    def test_redis_list_limit(self):
+        list_limit = settings.REDIS_LIST_LENGTH_LIMIT
+        page_size = EndlessPagination.page_size
+        users = [self.create_user('user{}'.format(i)) for i in range(5)]
+        newsfeeds = []
+        for i in range(list_limit + page_size):
+            tweet = self.create_tweet(user=users[i % 5], content='feed{}'.format(i))
+            feed = self.create_newsfeed(self.lisa, tweet)
+            newsfeeds.append(feed)
+        newsfeeds = newsfeeds[::-1] # 真实的 newsfeed 会倒过来
+
+        # only cached list_limit objects
+        cached_newsfeeds = NewsFeedService.get_cached_newsfeeds(self.lisa.id)
+        self.assertEqual(len(cached_newsfeeds), list_limit)
+        queryset = NewsFeed.objects.filter(user=self.lisa)
+        self.assertEqual(queryset.count(), list_limit + page_size)
+
+        results = self._paginate_to_get_newsfeeds(self.lisa_client)
+        self.assertEqual(len(results), list_limit + page_size)
+        for i in range(list_limit + page_size):
+            self.assertEqual(newsfeeds[i].id, results[i]['id'])
+
+        # a followed user create a new tweet
+        self.create_friendship(self.lisa, self.emma)
+        new_tweet = self.create_tweet(self.emma, 'a new tweet')
+        NewsFeedService.fanout_to_followers(new_tweet)
+
+        def _test_newsfeeds_after_new_feed_pushed():
+            results = self._paginate_to_get_newsfeeds(self.lisa_client)
+            self.assertEqual(len(results), list_limit + page_size + 1)
+            self.assertEqual(results[0]['tweet']['id'], new_tweet.id)
+            for i in range(list_limit + page_size):
+                self.assertEqual(newsfeeds[i].id, results[i + 1]['id'])
+
+        _test_newsfeeds_after_new_feed_pushed()
+
+        # cache expired
+        self.clear_cache()
+        _test_newsfeeds_after_new_feed_pushed()

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from newsfeeds.api.serializers import NewsFeedSerializer
+from newsfeeds.models import NewsFeed
 from newsfeeds.services import NewsFeedService
 from utils.paginations import EndlessPagination
 
@@ -19,9 +20,13 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         """
         GET /api/newsfeeds/
         """
-        # page = self.paginate_queryset(self.get_queryset())
-        newsfeeds = NewsFeedService.get_cached_newsfeeds(request.user.id)
-        page = self.paginate_queryset(newsfeeds)
+        cached_newsfeeds = NewsFeedService.get_cached_newsfeeds(request.user.id)
+        # 用 EndlessPagination 的自己实现的 paginated_cached_list
+        page = self.paginator.paginate_cached_list(cached_newsfeeds, request)
+        # page 是 None 说明我现在请求的数据可能不在 cache 里，需要直接去 db 获取
+        if page is None:
+            queryset = NewsFeed.objects.filter(user=request.user)
+            page = self.paginate_queryset(queryset)
         serializer = NewsFeedSerializer(
             instance=page,
             context={'request': request},

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -5,6 +5,7 @@ from django.test import TestCase as DjangoTestCase
 from rest_framework.test import APIClient
 
 from comments.models import Comment
+from friendships.models import Friendship
 from likes.models import Like
 from newsfeeds.models import NewsFeed
 from tweets.models import Tweet
@@ -37,6 +38,9 @@ class TestCase(DjangoTestCase):
         # 不能写成 User.objects.create()
         # 因为 password 需要被加密, username 和 email 需要进行一些 normalize 处理
         return User.objects.create_user(username, email, password)
+
+    def create_friendship(self, from_user, to_user):
+        return Friendship.objects.create(from_user=from_user, to_user=to_user)
 
     def create_tweet(self, user, content=None):
         if content is None:

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -38,12 +38,26 @@ class TweetViewSet(viewsets.GenericViewSet):
         # tweets = Tweet.objects.filter(
         #     user_id=request.query_params['user_id']
         # ).order_by('-created_at')
-        tweets = TweetService.get_cached_tweets(
-            user_id=request.query_params['user_id'],
-        )
-        tweets = self.paginate_queryset(tweets)  # 增加翻页
+
+        # tweets = TweetService.get_cached_tweets(
+        #     user_id=request.query_params['user_id'],
+        # )
+        # tweets = self.paginate_queryset(tweets)  # 增加翻页
+
+        user_id = request.query_params['user_id']
+        cached_tweets = TweetService.get_cached_tweets(user_id)
+        page = self.paginator.paginate_cached_list(cached_tweets, request)
+        if page is None:
+            # 这句查询会被翻译为
+            # select * from twitter_tweets
+            # where user_id = xxx
+            # order by created_at desc
+            # 这句 SQL 查询会用到 user 和 created_at 的联合索引
+            # 单纯的 user 索引是不够的
+            queryset = Tweet.objects.filter(user_id=user_id).order_by('-created_at')
+            page = self.paginate_queryset(queryset)
         serializer = TweetSerializer(
-            instance=tweets,
+            instance=page,
             context={'request': request},
             many=True,  # list of dict
         )

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -202,6 +202,7 @@ REDIS_HOST = '127.0.0.1'
 REDIS_PORT = 6379
 REDIS_DB = 0 if TESTING else 1
 REDIS_KEY_EXPIRE_TIME = 7 * 86400  # 7 days in seconds
+REDIS_LIST_LENGTH_LIMIT = 1000 if not TESTING else 20
 
 try:
     from .local_settings import *

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -1,11 +1,12 @@
 from dateutil import parser
+from django.conf import settings
 from rest_framework.pagination import BasePagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 
 class EndlessPagination(BasePagination):
-    page_size = 20
+    page_size = 20 if not settings.TESTING else 10
 
     def __init__(self):
         super(EndlessPagination, self).__init__()
@@ -40,9 +41,6 @@ class EndlessPagination(BasePagination):
         return reverse_ordered_list[index: index + self.page_size]
 
     def paginate_queryset(self, queryset, request: Request, view=None):
-        if type(queryset) == list:
-            return self.paginate_ordered_list(queryset, request)
-
         # 获得更新内容
         if 'created_at__gt' in request.query_params:
             # created_at__gt 用于下拉刷新的时候加载最新的内容进来
@@ -67,6 +65,22 @@ class EndlessPagination(BasePagination):
         queryset = queryset.order_by('-created_at')[:self.page_size + 1]
         self.has_next_page = len(queryset) > self.page_size
         return queryset[:self.page_size]  # 返回前端的还是 page_size 个
+
+    def paginate_cached_list(self, cached_list, request):
+        paginated_list = self.paginate_ordered_list(cached_list, request)
+        # 如果是上翻页，paginated_list 里是所有的最新的数据，直接返回
+        if 'created_at__gt' in request.query_params:
+            return paginated_list
+        # 如果是下翻页
+        # 如果还有下一页，说明 cached_list 里的数据还没有取完，也直接返回
+        if self.has_next_page:
+            return paginated_list
+        # 没有下一页了
+        # 如果 cached_list 的长度不足最大限制，说明 cached_list 里已经是所有数据了
+        if len(cached_list) < settings.REDIS_LIST_LENGTH_LIMIT:
+            return paginated_list
+        # 如果进入这里，说明可能存在在数据库里没有 load 在 cache 里的数据，需要直接去数据库查询
+        return None
 
     def get_paginated_response(self, data):
         return Response({

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -11,7 +11,10 @@ class RedisHelper:
         conn = RedisClient.get_connection()
 
         serialized_list = []
-        for obj in objects:
+        # 最多只 cache REDIS_LIST_LENGTH_LIMIT 那么多个 objects
+        # 超过这个限制的 objects，就去数据库里读取。一般这个限制会比较大，比如 1000
+        # 因此翻页翻到 1000 的用户访问量会比较少，从数据库读取也不是大问题
+        for obj in objects[:settings.REDIS_LIST_LENGTH_LIMIT]:
             serialized_data = DjangoModelSerializer.serialize(obj)
             serialized_list.append(serialized_data)
 
@@ -52,3 +55,4 @@ class RedisHelper:
         # key 存在，直接加入 cache 中
         serialized_data = DjangoModelSerializer.serialize(obj)
         conn.lpush(key, serialized_data)
+        conn.ltrim(name=key, start=0, end=settings.REDIS_LIST_LENGTH_LIMIT - 1)


### PR DESCRIPTION
1. Limit the size of cache: only cache the latest newsfeed so that the redis memory will not explode; the old newsfeed still goes through the database
2. Add unit test to test the cache size limit