### PR TITLE
Cache likes_count and comments_count

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -162,3 +162,41 @@ class CommentApiTests(TestCase):
         response = self.emma_client.get(NEWSFEED_LIST_API)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['results'][0]['tweet']['comments_count'], 2)
+
+    def test_comments_count_with_cache(self):
+        tweet_url = '/api/tweets/{}/'.format(self.tweet.id)
+        response = self.lisa_client.get(tweet_url)
+        self.assertEqual(self.tweet.comments_count, 0)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        data = {'tweet_id': self.tweet.id, 'content': 'a comment'}
+        for i in range(2):
+            _, client = self.create_user_and_client('user{}'.format(i))
+            client.post(COMMENT_URL, data)
+            response = client.get(tweet_url)
+            self.assertEqual(response.data['comments_count'], i + 1)
+            self.tweet.refresh_from_db()
+            self.assertEqual(self.tweet.comments_count, i + 1)
+
+        comment_data = self.emma_client.post(COMMENT_URL, data).data
+        response = self.emma_client.get(tweet_url)
+        self.assertEqual(response.data['comments_count'], 3)
+        self.tweet.refresh_from_db()
+        self.assertEqual(self.tweet.comments_count, 3)
+
+        # update comment shouldn't update comments_count
+        comment_url = '{}{}/'.format(COMMENT_URL, comment_data['id'])
+        response = self.emma_client.put(comment_url, {'content': 'updated'})
+        self.assertEqual(response.status_code, 200)
+        response = self.emma_client.get(tweet_url)
+        self.assertEqual(response.data['comments_count'], 3)
+        self.tweet.refresh_from_db()
+        self.assertEqual(self.tweet.comments_count, 3)
+
+        # delete a comment will update comments_count
+        response = self.emma_client.delete(comment_url)
+        self.assertEqual(response.status_code, 200)
+        response = self.lisa_client.get(tweet_url)
+        self.assertEqual(response.data['comments_count'], 2)
+        self.tweet.refresh_from_db()
+        self.assertEqual(self.tweet.comments_count, 2)

--- a/comments/listeners.py
+++ b/comments/listeners.py
@@ -1,4 +1,5 @@
 from utils.listeners import invalidate_object_cache
+from utils.redis_helper import RedisHelper
 
 
 def incr_comments_count(sender, instance, created, **kwargs):
@@ -13,7 +14,7 @@ def incr_comments_count(sender, instance, created, **kwargs):
         .update(comments_count=F('comments_count') + 1)
     # update 操作不会触发 invalidate_object_cache
     # 想让它触发 tweet 的 post_save 逻辑，就要手动触发
-    invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.incr_count(instance.tweet, 'comments_count')
 
 
 def decr_comments_count(sender, instance, **kwargs):
@@ -23,4 +24,4 @@ def decr_comments_count(sender, instance, **kwargs):
     # handle comment deletion
     Tweet.objects.filter(id=instance.tweet_id)\
         .update(comments_count=F('comments_count') - 1)
-    invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.decr_count(instance.tweet, 'comments_count')

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -238,3 +238,43 @@ class LikeApiTests(TestCase):
         self.assertEqual(tweet.likes_count, 0)
         response = self.emma_client.get(tweet_url)
         self.assertEqual(response.data['likes_count'], 0)
+
+    def test_likes_count_with_cache(self):
+        tweet = self.create_tweet(self.lisa)
+        self.create_newsfeed(self.lisa, tweet)
+        self.create_newsfeed(self.emma, tweet)
+
+        data = {'content_type': 'tweet', 'object_id': tweet.id}
+        tweet_url = TWEET_DETAIL_API.format(tweet.id)
+        for i in range(3):
+            _, client = self.create_user_and_client('someone{}'.format(i))
+            client.post(LIKE_BASE_URL, data)
+            # check tweet api
+            response = client.get(tweet_url)
+            self.assertEqual(response.data['likes_count'], i + 1)
+            tweet.refresh_from_db()
+            self.assertEqual(tweet.likes_count, i + 1)
+
+        self.emma_client.post(LIKE_BASE_URL, data)
+        response = self.emma_client.get(tweet_url)
+        self.assertEqual(response.data['likes_count'], 4)
+        tweet.refresh_from_db()
+        self.assertEqual(tweet.likes_count, 4)
+
+        # check newsfeed api
+        newsfeed_url = '/api/newsfeeds/'
+        response = self.lisa_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 4)
+        response = self.emma_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 4)
+
+        # emma canceled likes
+        self.emma_client.post(LIKE_BASE_URL + 'cancel/', data)
+        tweet.refresh_from_db()
+        self.assertEqual(tweet.likes_count, 3)
+        response = self.emma_client.get(tweet_url)
+        self.assertEqual(response.data['likes_count'], 3)
+        response = self.lisa_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 3)
+        response = self.emma_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 3)

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -8,6 +8,7 @@ from likes.services import LikeService
 from tweets.constants import TWEET_PHOTOS_UPLOAD_LIMIT
 from tweets.models import Tweet
 from tweets.services import TweetService
+from utils.redis_helper import RedisHelper
 
 
 class TweetSerializer(serializers.ModelSerializer):
@@ -35,13 +36,19 @@ class TweetSerializer(serializers.ModelSerializer):
         """
         查看有多少人评论了当前 object (tweet)
         """
-        return obj.comment_set.count()  # django的ForeignKey的反查机制
+        # return obj.comment_set.count()  # django的ForeignKey的反查机制
+        return RedisHelper.get_count(obj, 'comments_count')
 
     def get_likes_count(self, obj: Tweet):
         """
         查看有多少人点赞了当前 object (tweet)
         """
-        return obj.like_set.count()  # like_set为自定义的 Tweet 的 property
+        # return obj.like_set.count()  # like_set为自定义的 Tweet 的 property
+        # select count(*) -> redis get
+        # N + 1 queries
+        # 如果 N 是 db queries -> 不可接受的
+        # 如果 N 是 redis/memcached queries -> 可以接受
+        return RedisHelper.get_count(obj, 'likes_count')
 
     def get_has_liked(self, obj: Tweet):
         """

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -45,6 +45,7 @@ class TweetViewSet(viewsets.GenericViewSet):
         # tweets = self.paginate_queryset(tweets)  # 增加翻页
 
         user_id = request.query_params['user_id']
+        tweets = Tweet.objects.filter(user_id=user_id).prefetch_related('user')
         cached_tweets = TweetService.get_cached_tweets(user_id)
         page = self.paginator.paginate_cached_list(cached_tweets, request)
         if page is None:

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -56,3 +56,51 @@ class RedisHelper:
         serialized_data = DjangoModelSerializer.serialize(obj)
         conn.lpush(key, serialized_data)
         conn.ltrim(name=key, start=0, end=settings.REDIS_LIST_LENGTH_LIMIT - 1)
+
+    @classmethod
+    def get_count_key(cls, obj, attr):
+        return '{}.{}:{}'.format(obj.__class__.__name__, attr, obj.id)
+
+    @classmethod
+    def incr_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        if conn.exists(key):
+            return conn.incr(key)
+
+        # back fill from db
+        # 重新从数据库把 obj 给 load一下
+        # 不执行 +1 操作，因为必须保证调用 incr_count 之前 obj.attr 已经 +1 过了
+        obj.refresh_from_db()
+        conn.set(key, getattr(obj, attr))
+        conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+        return getattr(obj, attr)
+
+
+    @classmethod
+    def decr_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        if conn.exists(key):
+            return conn.decr(key)
+
+        # 重新从数据库把 obj 给 load一下
+        # 不执行 -1 操作，因为必须保证调用 incr_count 之前 obj.attr 已经 -1 过了
+        obj.refresh_from_db()
+        conn.set(key, getattr(obj, attr))
+        conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+        return getattr(obj, attr)
+
+    @classmethod
+    def get_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        count = conn.get(key)
+        if count is not None:
+            return int(count)
+
+        # 重新从数据库把 obj 给 load一下
+        obj.refresh_from_db()
+        count = getattr(obj, attr)
+        conn.set(key, count)
+        return count


### PR DESCRIPTION
经常变动的 likes_count 和 comments_count 要单独进行存储，而不是和 tweet 的 cache 一起存储

1. Cache likes_count and comments_count in redis
2. Add unit test `test_likes_count_with_cache` and `test_comments_count_with_cache`