### PR TITLE
Split fanout task into batch async task

### DIFF
--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -11,7 +11,6 @@ from friendships.api.serializers import (
     FollowingSerializer, FriendshipSerializerForCreate,
 )
 from friendships.models import Friendship
-from friendships.services import FriendshipService
 
 
 class FriendshipViewSet(viewsets.GenericViewSet):

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -22,6 +22,11 @@ class FriendshipService:
         return followers
 
     @classmethod
+    def get_follower_ids(cls, to_user_id):
+        friendships = Friendship.objects.filter(to_user_id=to_user_id)
+        return [friendship.from_user_id for friendship in friendships]
+
+    @classmethod
     def get_following_user_id_set(cls, from_user_id):
         """
         通过一次的数据库访问将当前登录用户的 following user id 存进 memcached 的 cache 中

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -11,10 +11,10 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
     pagination_class = EndlessPagination
 
-    # def get_queryset(self):
-    #     # 重载以自定义 queryset，因为 newsfeed 的查看是有权限的
-    #     # 只能看 user=当前登录用户的 newsfeed
-    #     return NewsFeed.objects.filter(user_id=self.request.user.id)
+    def get_queryset(self):
+        # 重载以自定义 queryset，因为 newsfeed 的查看是有权限的
+        # 只能看 user=当前登录用户的 newsfeed
+        return NewsFeed.objects.filter(user_id=self.request.user.id)
 
     def list(self, request: Request):
         """

--- a/newsfeeds/constants.py
+++ b/newsfeeds/constants.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+FANOUT_BATCH_SIZE = 1000 if not settings.TESTING else 3

--- a/newsfeeds/services.py
+++ b/newsfeeds/services.py
@@ -1,5 +1,5 @@
 from newsfeeds.models import NewsFeed
-from newsfeeds.tasks import fanout_newsfeeds_task
+from newsfeeds.tasks import fanout_newsfeeds_main_task
 from twitter.cache import USER_NEWSFEEDS_PATTERN
 from utils.redis_helper import RedisHelper
 
@@ -20,7 +20,10 @@ class NewsFeedService:
         # 没有办法知道当前 web 进程的某片内存空间里的值是什么。
         # 所以我们只能把 tweet.id 作为参数传进去，而不能把 tweet 传进去。
         # 因为 celery 并不知道如何 serialize Tweet。
-        fanout_newsfeeds_task.delay(tweet.id) # delay() 表示异步任务
+        # delay() 表示异步任务
+        fanout_newsfeeds_main_task.delay(tweet.id, tweet.user_id)
+        # tweet.user_id 不会产生额外数据库查询，tweet.user.id 会产生额外数据库查询
+
         # fanout_newsfeeds_task(tweet.id) # 同步任务
 
     @classmethod

--- a/newsfeeds/tasks.py
+++ b/newsfeeds/tasks.py
@@ -1,13 +1,13 @@
 from celery import shared_task
 
 from friendships.services import FriendshipService
+from newsfeeds.constants import FANOUT_BATCH_SIZE
 from newsfeeds.models import NewsFeed
-from tweets.models import Tweet
 from utils.time_constants import ONE_HOUR
 
 
-@shared_task(time_limit=ONE_HOUR)
-def fanout_newsfeeds_task(tweet_id):
+@shared_task(routing_key='newsfeeds', time_limit=ONE_HOUR)
+def fanout_newsfeeds_batch_task(tweet_id, follower_ids):
     # import 写在里面避免循环依赖
     from newsfeeds.services import NewsFeedService
 
@@ -20,13 +20,11 @@ def fanout_newsfeeds_task(tweet_id):
     #     )
     # 正确的方法：使用 bulk_create，会把 insert 语句合成一条
 
-    tweet = Tweet.objects.get(id=tweet_id)
     # 获取当前发帖人的所有粉丝
     newsfeeds = [
-        NewsFeed(user=follower, tweet=tweet)
-        for follower in FriendshipService.get_followers(tweet.user)
+        NewsFeed(user_id=follower_id, tweet_id=tweet_id)
+        for follower_id in follower_ids
     ]
-    newsfeeds.append(NewsFeed(user=tweet.user, tweet=tweet))  # 自己也能看自己发的帖子
 
     # 一次性写入
     NewsFeed.objects.bulk_create(objs=newsfeeds)
@@ -36,6 +34,8 @@ def fanout_newsfeeds_task(tweet_id):
     for newsfeed in newsfeeds:
         NewsFeedService.push_newsfeed_to_cache(newsfeed)
 
+    return '{} newsfeeds created'.format(len(newsfeeds))
+
     # 其实若是一个 1kw 粉丝的博主发了一个 144字节的 tweet，
     # 如果把整个 tweet 去 fan out 到 1kw 粉丝中，会给 redis 的内存带来 1G 的耗费
     # 可进一步优化：在 newsfeed cache 中，不直接存储整个 tweet，而是只存 tweet id
@@ -44,3 +44,23 @@ def fanout_newsfeeds_task(tweet_id):
     # 只有 user_id，tweet_id，和 created_at，并没有整条 tweet
 
     # 本质优化方法：对于明星用户，不要用 push model，而要用 pull model
+
+@shared_task(routing_key='default', time_limit=ONE_HOUR)
+def fanout_newsfeeds_main_task(tweet_id, tweet_user_id):
+    # 将推给自己的 Newsfeed 率先创建，确保自己能最快看到
+    NewsFeed.objects.create(user_id=tweet_user_id, tweet_id=tweet_id)
+
+    # 在具体的 async task 中进行拆分，拆成一个个小的 async task
+
+    # 获得所有的 follower ids，按照 batch size 拆分开
+    follower_ids = FriendshipService.get_follower_ids(tweet_user_id)
+    index = 0
+    while index < len(follower_ids):
+        batch_ids = follower_ids[index: index + FANOUT_BATCH_SIZE]
+        fanout_newsfeeds_batch_task.delay(tweet_id, batch_ids) # 拆成小的async task
+        index += FANOUT_BATCH_SIZE
+
+    return '{} newsfeeds going to fanout, {} batches created.'.format(
+        len(follower_ids),
+        (len(follower_ids) - 1) // FANOUT_BATCH_SIZE + 1,
+    )

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
+from kombu import Queue
 from pathlib import Path
 
 import sys
@@ -211,6 +212,10 @@ CELERY_BROKER_URL = 'redis://127.0.0.1:6379/2' if not TESTING \
     else 'redis://127.0.0.1:6379/0'
 CELERY_TIMEZONE = "UTC"
 CELERY_TASK_ALWAYS_EAGER = TESTING
+CELERY_QUEUES = (
+    Queue('default', routing_key='default'),
+    Queue('newsfeeds', routing_key='newsfeeds'),
+)
 
 try:
     from .local_settings import *


### PR DESCRIPTION
1. Make fanout robust by batch jobs
2. Add unit test to test newsfeeds fanout main task

- 问题：异步任务虽然可以执行很长时间，但是执行时间过长，潜在风险急剧上升：e.g. 数据库连接超时
解决方案：在具体的 async task 中分批次/批量化，拆分任务成多个 async task 分发到多台机器上，并发执行；拆分和主逻辑没关系

- 问题：过多 newsfeeds 任务导致其它任务堵塞
解决方案：
    - 法一：多个 message queue 等概率出任务，每个 message queue 中的任务自己排队
    - 法二：100台worker，90台专门做 newsfeeds 任务，其余10台做 default 任务
```
import os
if os.environ.get('WORKER_TYPE') == 'newsfeeds':
    CELERY_QUEUES = (
        Queue('newsfeeds', routing_key='newsfeeds'),
    )
else:
    CELERY_QUEUES = (
        Queue('default', routing_key='default'),
    )
```