### PR TITLE
Add rate limit

### DIFF
--- a/accounts/api/views.py
+++ b/accounts/api/views.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.models import User
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework import permissions
@@ -34,6 +36,7 @@ class AccountViewSet(viewsets.ViewSet):
     serializer_class = SignupSerializer
 
     @action(methods=['GET'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='GET', block=True))
     def login_status(self, request):
         """
         查看用户当前的登录状态和具体信息
@@ -47,6 +50,7 @@ class AccountViewSet(viewsets.ViewSet):
         return Response(data)
 
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='POST', block=True))
     def login(self, request):
         """
         使用 username, password 进行注册
@@ -91,6 +95,7 @@ class AccountViewSet(viewsets.ViewSet):
 
 
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='POST', block=True))
     def logout(self, request):
         """
         登出当前用户
@@ -99,6 +104,7 @@ class AccountViewSet(viewsets.ViewSet):
         return Response({'success': True})
 
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='POST', block=True))
     def signup(self, request):
         """
         使用 username, email, password 进行注册

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.request import Request
@@ -33,6 +35,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         return [AllowAny()]
 
     @required_params(method='GET', params=['tweet_id'])
+    @method_decorator(ratelimit(key='user', rate='10/s', method='GET', block=True))
     def list(self, request: Request):
         """
         重载 list 方法，不列出所有 comments，
@@ -57,6 +60,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             'comments': serializer.data,
         }, status=status.HTTP_200_OK)
 
+    @method_decorator(ratelimit(key='user', rate='3/s', method='POST', block=True))
     def create(self, request: Request):
         """
         POST /api/comments/
@@ -89,6 +93,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    @method_decorator(ratelimit(key='user', rate='3/s', method='POST', block=True))
     def update(self, request: Request, *args, **kwargs):
         """
         PUT /api/comments/<pk>/
@@ -124,6 +129,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @method_decorator(ratelimit(key='user', rate='5/s', method='POST', block=True))
     def destroy(self, request: Request, *args, **kwargs):
         """
         DELETE /api/comments/<pk>/

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.models import User
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -21,6 +23,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
     pagination_class = FriendshipPagination
 
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
+    @method_decorator(ratelimit(key='user_or_ip', rate='3/s', method='GET', block=True))
     def followers(self, request: Request, pk):
         """
         GET /api/friendships/<pk>/followers/ 返回 user_id=<pk> 的用户的所有粉丝
@@ -36,6 +39,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         return self.get_paginated_response(data=serializer.data)
 
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
+    @method_decorator(ratelimit(key='user_or_ip', rate='3/s', method='GET', block=True))
     def followings(self, request: Request, pk):
         """
         GET /api/friendships/<pk>/followings/ 返回 user_id=<pk> 的用户关注的所有用户
@@ -51,6 +55,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         return self.get_paginated_response(data=serializer.data)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
+    @method_decorator(ratelimit(key='user', rate='10/s', method='POST', block=True))
     def follow(self, request: Request, pk):
         """
         POST /api/friendships/<pk>/follow/ 当前用户去关注 user_id=<pk> 的用户
@@ -92,6 +97,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
         }, status=status.HTTP_201_CREATED)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
+    @method_decorator(ratelimit(key='user', rate='10/s', method='POST', block=True))
     def unfollow(self, request: Request, pk):
         """
         POST /api/friendships/<pk>/unfollow/ 当前用户去取关 user_id=<pk> 的用户

--- a/inbox/api/views.py
+++ b/inbox/api/views.py
@@ -1,4 +1,6 @@
+from django.utils.decorators import method_decorator
 from notifications.models import Notification
+from ratelimit.decorators import ratelimit
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -25,6 +27,7 @@ class NotificationViewSet(viewsets.GenericViewSet,
         return Notification.objects.filter(recipient=self.request.user).all()
 
     @action(methods=['GET'], detail=False, url_path='unread-count')
+    @method_decorator(ratelimit(key='user', rate='3/s', method='GET', block=True))
     def unread_count(self, request: Request):
         """
         GET /api/notifications/unread-count/
@@ -35,6 +38,7 @@ class NotificationViewSet(viewsets.GenericViewSet,
         }, status=status.HTTP_200_OK)
 
     @action(methods=['POST'], detail=False, url_path='mark-all-as-read')
+    @method_decorator(ratelimit(key='user', rate='3/s', method='POST', block=True))
     def mark_all_as_read(self, request: Request):
         """
         POST /api/notifications/mark-all-as-read/
@@ -45,6 +49,7 @@ class NotificationViewSet(viewsets.GenericViewSet,
         }, status=status.HTTP_200_OK)
 
     @required_params(method='PUT', params=['unread'])
+    @method_decorator(ratelimit(key='user', rate='3/s', method='POST', block=True))
     def update(self, request: Request, *args, **kwargs):
         """
         PUT /api/notifications/<pk>/

--- a/likes/api/views.py
+++ b/likes/api/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -20,6 +22,7 @@ class LikeViewSet(viewsets.GenericViewSet):
     serializer_class = LikeSerializerForCreate
 
     @required_params(method='POST', params=['content_type', 'object_id'])
+    @method_decorator(ratelimit(key='user', rate='10/s', method='POST', block=True))
     def create(self, request: Request):
         """
         POST /api/likes/
@@ -49,6 +52,7 @@ class LikeViewSet(viewsets.GenericViewSet):
 
     @action(methods=['POST'], detail=False)
     @required_params(method='POST', params=['content_type', 'object_id'])
+    @method_decorator(ratelimit(key='user', rate='10/s', method='POST', block=True))
     def cancel(self, request: Request):
         """
         POST /api/likes/cancel/

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -16,6 +18,7 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         # 只能看 user=当前登录用户的 newsfeed
         return NewsFeed.objects.filter(user_id=self.request.user.id)
 
+    @method_decorator(ratelimit(key='user', rate='5/s', method='GET', block=True))
     def list(self, request: Request):
         """
         GET /api/newsfeeds/

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ django-debug-toolbar==3.2.1
 django-filter==2.4.0
 django-model-utils==4.1.1
 django-notifications-hq==1.6.0
+django-ratelimit==3.0.1
 django-storages==1.11.1
 djangorestframework==3.12.2
 httplib2==0.9.2

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -64,6 +64,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',
     ],
+    'EXCEPTION_HANDLER': 'utils.ratelimit.exception_handler',
 }
 
 MIDDLEWARE = [
@@ -194,6 +195,12 @@ CACHES = {
         'TIMEOUT': 86400,
         'KEY_PREFIX': 'testing',
     },
+    'ratelimit': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 86400 * 7,
+        'KEY_PREFIX': 'rl',
+    },
 }
 
 # Redis
@@ -216,6 +223,12 @@ CELERY_QUEUES = (
     Queue('default', routing_key='default'),
     Queue('newsfeeds', routing_key='newsfeeds'),
 )
+
+# Rate Limiter
+RATELIMIT_USE_CACHE = 'ratelimit'
+RATELIMIT_CACHE_PREFIX = 'rl:'   # 避免和其他的 key 冲突
+RATELIMIT_ENABLE = not TESTING  # 在某些环境下，比如内部测试等环境下，一般也会关掉
+
 
 try:
     from .local_settings import *

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -1,0 +1,16 @@
+from ratelimit.exceptions import Ratelimited
+from rest_framework import status
+from rest_framework.views import exception_handler as drf_exception_handler
+
+
+def exception_handler(exc, context):
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = drf_exception_handler(exc, context)
+
+    # Now add the HTTP status code to the response
+    if isinstance(exc, Ratelimited):
+        response.data['detail'] = 'Too many requests, try again later.'
+        response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+
+    return response


### PR DESCRIPTION
限流器：保护数据库，以防流量过大
对已登录用户的选择，一般是user_id；对于未登录用户的选择，一般是ip，或是正在操作的对象，如phone number/email
限制的颗粒度，一般是s, m, h, 最多到d

1. `pip install django-ratelimit`
2. Add rate limit to all api view methods